### PR TITLE
Update Building_AOSP. Scripts have changed

### DIFF
--- a/Guides/Building_AOSP.txt
+++ b/Guides/Building_AOSP.txt
@@ -33,10 +33,8 @@ $ ls
 $ bash setup/<script-name>
 
 Run the script corresponding to your Linux Distribution:
-arch-manjaro-apricity-build-environment-setup.sh - Arch based distros
-ubuntu1604linuxmint18.sh - Ubuntu 16.04 or higher based distros
-ubuntu1404.sh - Ubuntu 14.04
-linuxmint17x.sh - Linux Mint 17.x
+arch-manjaro.sh - Arch based distros
+android_build_env.sh - Ubuntu 14, Ubuntu 16, Ubuntu 18, Mint 19
 
 Manual way:
 -- Grab Java 8:


### PR DESCRIPTION
I'm not the maintainer of the scripts.
I just wanted to build a ROM and noticed that the referenced scripts are no longer available.
According to https://github.com/akhilnarang/scripts/commit/39f137ec2150195177b801ebe221121c7bfa6412 
android_build_env.sh now takes care of Ubuntu 14, Ubuntu 16, Ubuntu 18 and Mint 19